### PR TITLE
Use next-cloudinary for images

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from 'react';
 import { LoginForm } from '@/components/auth/login-form';
 import { Card, CardHeader, CardTitle } from '@/components/ui/card';
 import { ImageModal } from '@/components/ui/image-modal';
-import Image from 'next/image';
+import { CldImage } from 'next-cloudinary';
 import { SESSION_KEY } from '@/lib/constants';
 
 interface TravelCard {
@@ -82,7 +82,7 @@ export default function Home() {
             onClick={() => setSelectedCard(card)}
           >
             <div className="relative h-48">
-              <Image
+              <CldImage
                 src={card.imageUrl}
                 alt={card.title}
                 fill

--- a/components/ui/image-modal.tsx
+++ b/components/ui/image-modal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Dialog, DialogContent } from '@/components/ui/dialog';
-import Image from 'next/image';
+import { CldImage } from 'next-cloudinary';
 
 interface ImageModalProps {
   isOpen: boolean;
@@ -16,7 +16,7 @@ export function ImageModal({ isOpen, onClose, imageUrl, title, description }: Im
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent className="sm:max-w-[800px] z-[200] [&>div]:z-[180]">
         <div className="relative aspect-video w-full">
-          <Image src={imageUrl} alt={title} fill className="object-cover rounded-lg" />
+          <CldImage src={imageUrl} alt={title} fill className="object-cover rounded-lg" />
         </div>
         <div className="mt-4">
           <h3 className="text-xl font-semibold">{title}</h3>

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "react-resizable-panels": "^2.1.7",
     "recharts": "^2.15.2",
     "sonner": "^1.4.0",
+    "next-cloudinary": "^2.0.0",
     "tailwind-merge": "^2.2.1",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^1.1.2",


### PR DESCRIPTION
## Summary
- swap `next/image` for `next-cloudinary` on cards
- update image modal to use `next-cloudinary`
- add `next-cloudinary` dependency

## Testing
- `pnpm lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840cd52d4b483258d250321eb7f8735