### PR TITLE
Connect Edge Config

### DIFF
--- a/app/api/travel-cards/route.ts
+++ b/app/api/travel-cards/route.ts
@@ -1,0 +1,13 @@
+import { get } from '@vercel/edge-config';
+import { NextResponse } from 'next/server';
+
+export const runtime = 'edge';
+
+export async function GET() {
+  try {
+    const cards = await get('travelCards');
+    return NextResponse.json(cards ?? []);
+  } catch (error) {
+    return NextResponse.json({ error: 'Failed to fetch travel cards' }, { status: 500 });
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,29 +15,9 @@ interface TravelCard {
   author: string;
 }
 
-const travelCards: TravelCard[] = [
-  {
-    id: 1,
-    title: 'Santorini, Greece',
-    imageUrl: 'santorini_keamhc',
-    author: 'Edsel Serrano',
-  },
-  {
-    id: 2,
-    title: 'Kyoto, Japan',
-    imageUrl: 'https://images.unsplash.com/photo-1492571350019-22de08371fd3?q=80&w=1000',
-    author: 'Edsel Serrano',
-  },
-  {
-    id: 3,
-    title: 'Machu Picchu, Peru',
-    imageUrl: 'https://images.unsplash.com/photo-1526392060635-9d6019884377?q=80&w=1000',
-    author: 'Edsel Serrano',
-  },
-];
-
 export default function Home() {
   const [hasSession, setHasSession] = useState(false);
+  const [travelCards, setTravelCards] = useState<TravelCard[]>([]);
   const [selectedCard, setSelectedCard] = useState<TravelCard | null>(null);
   const [mounted, setMounted] = useState(false);
 
@@ -48,6 +28,19 @@ export default function Home() {
       setHasSession(session === 'authenticated');
     }
   }, [mounted]);
+
+  useEffect(() => {
+    async function fetchCards() {
+      try {
+        const response = await fetch('/api/travel-cards');
+        const data = await response.json();
+        setTravelCards(data);
+      } catch (error) {
+        console.error('Failed to load travel cards', error);
+      }
+    }
+    fetchCards();
+  }, []);
 
   if (!mounted) {
     return null;

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  output: 'export',
   eslint: {
     ignoreDuringBuilds: true,
   },
@@ -21,3 +20,4 @@ const nextConfig = {
 };
 
 module.exports = nextConfig;
+

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "tailwind-merge": "^2.2.1",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^1.1.2",
-    "zod": "^3.24.2"
+    "zod": "^3.24.2",
+    "@vercel/edge-config": "^1.2.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.24.0",


### PR DESCRIPTION
## Summary
- add `@vercel/edge-config` package
- create Edge API route for travel cards
- fetch travel cards from API in main page
- allow dynamic routes by removing `output: 'export'`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840d7f262e88325b42ced16ba620603