### PR TITLE
feat: modern layout with blurred background

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,6 +10,7 @@ import { Inter } from 'next/font/google';
 import { cn } from '@/lib/utils';
 import { ThemeToggle } from '@/components/ui/theme-toggle';
 import { SESSION_KEY } from '@/lib/constants';
+import Image from 'next/image';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -42,9 +43,12 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
           enableSystem
           disableTransitionOnChange
         >
-          <div className="min-h-screen bg-background">
+          <div className="relative flex min-h-screen flex-col">
+            <div className="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
+              <Image src="/blur-bg.svg" alt="" fill priority className="object-cover blur-3xl" />
+            </div>
             <Navigation onLogout={handleLogout} themeToggle={<ThemeToggle />} />
-            <main className="relative z-[100] pb-20 md:pb-0 md:pt-20">{children}</main>
+            <main className="relative z-10 flex-1 pb-20 md:pb-0 md:pt-20">{children}</main>
           </div>
           <Toaster />
         </ThemeProvider>

--- a/public/blur-bg.svg
+++ b/public/blur-bg.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1e3a8a"/>
+      <stop offset="100%" stop-color="#9333ea"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="600" fill="url(#g)" />
+</svg>


### PR DESCRIPTION
## Summary
- refresh layout with a flex-based structure
- add blurred gradient background image for a modern feel

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68bf59e4c3a883258a011ad12379aa3d